### PR TITLE
Needs to include spark_wiring_print.h

### DIFF
--- a/firmware/LiquidCrystal_I2C_Spark.cpp
+++ b/firmware/LiquidCrystal_I2C_Spark.cpp
@@ -26,8 +26,14 @@ bulldoglowell@gmail.com
 // can't assume that its in that state when a sketch starts (and the
 // LiquidCrystal constructor is called).
 
+#if defined(ARDUINO) && ARDUINO >= 100
+#include <Arduino.h>
+#include <Wire.h>
+#elif defined(SPARK)
 #include "application.h"
+#endif
 
+#include <inttypes.h>
 #include "LiquidCrystal_I2C_Spark.h"
 
 

--- a/firmware/LiquidCrystal_I2C_Spark.h
+++ b/firmware/LiquidCrystal_I2C_Spark.h
@@ -4,10 +4,19 @@ Modified timing of writes to accomodate SparkCore
 Jim Brower - 
 bulldoglowell@gmail.com
 */
-#include "application.h"
 
 #ifndef LiquidCrystal_I2C_Spark_h
 #define LiquidCrystal_I2C_Spark_h
+
+#if defined(ARDUINO) && ARDUINO >= 100
+#include "Arduino.h"
+#include <Print.h>
+#elif defined(SPARK)
+#include "application.h"
+#include <spark_wiring_print.h>
+#endif
+
+#include <inttypes.h>
 
 #define LCD_CLEARDISPLAY 0x01
 #define LCD_RETURNHOME 0x02

--- a/spark.json
+++ b/spark.json
@@ -1,7 +1,7 @@
 {
   "name": "LiquidCrystal_I2C_Spark",
-  "author": "Jim Brower <bulldoglowell@gmail.com>",
+  "author": "Jim Brower <bulldoglowell@gmail.com>, John Plocher <john.plocher@gmail.com>",
   "license": "GNU",
-  "version": "1.1.0",
-  "description": "LiquidCrystal_I2C ported for Spark Core"
+  "version": "1.1.1",
+  "description": "LiquidCrystal_I2C ported for Spark Core and Photon"
 }


### PR DESCRIPTION
On Photon, this lib won't compile without an explicit include of spark_wiring_print.h
